### PR TITLE
feat:UX enhancements in add item dialog

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -46,6 +46,7 @@ const Dialog = ({ onCancel, onConfirm }: Props) => {
             bg-transparent
             focus="border-b-check transition duration-300"
             value={inputVal}
+            placeholder="Deploy to Vercel..."
             onChange={(e) => setInputVal(e.target.value)}
           />
         </section>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "../style/dialog.css";
 import Button from "./Button";
 import { motion } from "framer-motion";
@@ -10,6 +10,11 @@ interface Props {
 
 const Dialog = ({ onCancel, onConfirm }: Props) => {
   const [inputVal, setInputVal] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (inputRef) inputRef.current!.focus();
+  }, []);
 
   return (
     <div className="dialog" onClick={() => onCancel(false)}>
@@ -48,6 +53,7 @@ const Dialog = ({ onCancel, onConfirm }: Props) => {
             value={inputVal}
             placeholder="Deploy to Vercel..."
             onChange={(e) => setInputVal(e.target.value)}
+            ref={inputRef}
           />
         </section>
 

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -12,8 +12,9 @@ const Dialog = ({ onCancel, onConfirm }: Props) => {
   const [inputVal, setInputVal] = useState("");
 
   return (
-    <div className="dialog">
+    <div className="dialog" onClick={() => onCancel(false)}>
       <motion.div
+        onClick={(e) => e.stopPropagation()}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -13,8 +13,15 @@ const Dialog = ({ onCancel, onConfirm }: Props) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (inputRef) inputRef.current!.focus();
+    inputRef.current?.focus();
   }, []);
+
+  function handleAcceptAddItem() {
+    if (!inputVal) return onCancel(false);
+
+    onConfirm(inputVal);
+    onCancel(false);
+  }
 
   return (
     <div className="dialog" onClick={() => onCancel(false)}>
@@ -57,12 +64,7 @@ const Dialog = ({ onCancel, onConfirm }: Props) => {
           />
         </section>
 
-        <Button
-          type="solid"
-          onClick={() => {
-            onConfirm(inputVal), onCancel(false);
-          }}
-        >
+        <Button type="solid" onClick={handleAcceptAddItem}>
           <span className="text-white font-600 w-full">OK</span>
         </Button>
       </motion.div>


### PR DESCRIPTION
Hi :)
Your app looks great!! I see that you used Framer Motion, I gotta try it out someday because those transitions look neat

Anyway, I'm trying to start contributing to open-source projects, even if it means making very small changes, so here is what I've changed:
- You can click outside of the Add item dialog to close it now
- Add an input placeholder to make it clear that you can type there
- Automatically focus the input so you can start typing without navigating with your mouse first
- Not saving empty strings to the local storage and effectively not displaying empty items